### PR TITLE
Querying ProfileConnection#digital_object_ids

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -187,6 +187,7 @@ Documentation:
 
 DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'
+  EnforcedStyle: trailing
   Enabled: true
 
 DoubleNegation:

--- a/app/models/orcid/profile_connection.rb
+++ b/app/models/orcid/profile_connection.rb
@@ -7,8 +7,9 @@ module Orcid
     include ActiveModel::Conversion
     extend ActiveModel::Naming
 
+    # See: http://support.orcid.org/knowledgebase/articles/132354-tutorial-searching-with-the-api
     class_attribute :available_query_attribute_names
-    self.available_query_attribute_names = [:email, :text]
+    self.available_query_attribute_names = [:email, :text, :digital_object_ids]
 
     available_query_attribute_names.each do |attribute_name|
       attribute attribute_name
@@ -68,7 +69,16 @@ module Orcid
     private :query_requested?
 
     def query_attributes
-      attributes.slice(*available_query_attribute_names)
+      available_query_attribute_names.each_with_object({}) do |name, mem|
+        orcid_formatted_name = convert_attribute_name_to_orcid_format(name)
+        mem[orcid_formatted_name] = attributes.fetch(name)
+        mem
+      end
     end
+
+    def convert_attribute_name_to_orcid_format(name)
+      name.to_s.gsub(/_+/, '-')
+    end
+    private :convert_attribute_name_to_orcid_format
   end
 end

--- a/spec/models/orcid/profile_connection_spec.rb
+++ b/spec/models/orcid/profile_connection_spec.rb
@@ -1,16 +1,18 @@
 require 'spec_helper'
 
+# :nodoc:
 module Orcid
   describe ProfileConnection do
-    let(:email) { 'test@hello.com'}
+    let(:email) { 'test@hello.com' }
+    let(:dois) { '123' }
     let(:user) { FactoryGirl.build_stubbed(:user) }
-    let(:profile_query_service) { double("Profile Lookup Service") }
+    let(:profile_query_service) { double('Profile Lookup Service') }
 
-    subject {
-      Orcid::ProfileConnection.new(email: email, user: user).tap { |pc|
+    subject do
+      Orcid::ProfileConnection.new(email: email, user: user).tap do |pc|
         pc.profile_query_service = profile_query_service
-      }
-    }
+      end
+    end
 
     its(:email) { should eq email }
     its(:to_model) { should eq subject }
@@ -22,11 +24,20 @@ module Orcid
       subject { Orcid::ProfileConnection.new.available_query_attribute_names }
       it { should include(:email) }
       it { should include(:text) }
+      it { should include(:digital_object_ids) }
     end
 
     context '#query_attributes' do
-      subject { Orcid::ProfileConnection.new(email: email, user: user)}
-      its(:query_attributes) { should eq(email: email, text: nil) }
+      subject do
+        Orcid::ProfileConnection.new(
+          email: email, user: user, digital_object_ids: dois
+        )
+      end
+      its(:query_attributes) do
+        should eq(
+          'email' => email, 'text' => nil, 'digital-object-ids' => dois
+        )
+      end
     end
 
     context '#query_requested?' do
@@ -35,27 +46,30 @@ module Orcid
         its(:query_requested?) { should eq false }
       end
       context 'with attribute set' do
-        subject { Orcid::ProfileConnection.new(email: email, user: user)}
+        subject { Orcid::ProfileConnection.new(email: email, user: user) }
         its(:query_requested?) { should eq true }
       end
     end
 
     context '#save' do
       let(:orcid_profile_id) { '1234-5678' }
-      let(:persister) { double("Persister") }
+      let(:persister) { double('Persister') }
 
       it 'should call the persister when valid' do
         subject.orcid_profile_id = orcid_profile_id
-        persister.should_receive(:call).with(user, orcid_profile_id).and_return(:persisted)
+        persister.should_receive(:call).
+          with(user, orcid_profile_id).
+          and_return(:persisted)
+
         expect(subject.save(persister: persister)).to eq(:persisted)
       end
 
       it 'should NOT call the persister and add errors when not valid' do
         subject.user = nil
         subject.orcid_profile_id = nil
-        expect {
-          subject.save(persister: persister)
-        }.to change { subject.errors.count }.by(2)
+
+        expect { subject.save(persister: persister) }.
+          to change { subject.errors.count }.by(2)
       end
     end
 
@@ -64,8 +78,14 @@ module Orcid
 
         it 'should yield the query response' do
           subject.email = email
-          profile_query_service.should_receive(:call).with(subject.query_attributes).and_return(:query_response)
-          expect {|b| subject.with_orcid_profile_candidates(&b) }.to yield_with_args(:query_response)
+
+          profile_query_service.
+            should_receive(:call).
+            with(subject.query_attributes).
+            and_return(:query_response)
+
+          expect { |b| subject.with_orcid_profile_candidates(&b) }.
+            to yield_with_args(:query_response)
         end
       end
 
@@ -73,7 +93,9 @@ module Orcid
         it 'should not yield' do
           subject.email = nil
           profile_query_service.stub(:call).and_return(:query_response)
-          expect {|b| subject.with_orcid_profile_candidates(&b) }.to_not yield_control
+
+          expect { |b| subject.with_orcid_profile_candidates(&b) }.
+            to_not yield_control
         end
       end
 


### PR DESCRIPTION
I am wanting to allow "digital-object-ids" as part of the query
parameters for connecting an Orcid profile.

In talking with people from orcid.org it was suggested that looking up
profiles is best done via Email and DOIs.

See for available parameters:
http://support.orcid.org/knowledgebase/articles/132354-tutorial-searching-with-the-api

@TODO - It would be nice to properly label these.

@ASIDE - I updated .hound.yml to reflect how I want it parsed.
