### PR TITLE
Adding error handling for "weird" search results

### DIFF
--- a/app/services/orcid/remote/profile_query_service.rb
+++ b/app/services/orcid/remote/profile_query_service.rb
@@ -9,11 +9,12 @@ module Orcid
       end
 
       attr_reader :token, :path, :headers, :response_builder, :query_builder
+      attr_reader :parser
       def initialize(config = {}, &callbacks)
         super(&callbacks)
         @query_builder = config.fetch(:query_parameter_builder) { QueryParameterBuilder }
         @token = config.fetch(:token) { default_token }
-        @response_builder = config.fetch(:response_builder) { SearchResponse }
+        @parser = config.fetch(:parser) { ResponseParser }
         @path = config.fetch(:path) { 'v1.1/search/orcid-bio/' }
         @headers = config.fetch(:headers) { default_headers }
       end
@@ -41,7 +42,7 @@ module Orcid
       end
 
       def issue_callbacks(search_results)
-        if search_results.any?
+        if Array(search_results).flatten.compact.any?
           callback(:found, search_results)
         else
           callback(:not_found)
@@ -54,27 +55,7 @@ module Orcid
       end
 
       def parse(document)
-        json = JSON.parse(document)
-
-        json.fetch('orcid-search-results').fetch('orcid-search-result')
-        .each_with_object([]) do |result, returning_value|
-          profile = result.fetch('orcid-profile')
-          identifier = profile.fetch('orcid-identifier').fetch('path')
-          orcid_bio = profile.fetch('orcid-bio')
-          given_names = orcid_bio.fetch('personal-details').fetch('given-names').fetch('value')
-          family_name = orcid_bio.fetch('personal-details').fetch('family-name').fetch('value')
-          emails = []
-          contact_details = orcid_bio['contact-details']
-          if contact_details
-            emails = (contact_details['email'] || []).map {|email| email.fetch('value') }
-          end
-          label = "#{given_names} #{family_name}"
-          label << ' (' << emails.join(', ') << ')' if emails.any?
-          label << " [ORCID: #{identifier}]"
-          biography = ''
-          biography = orcid_bio['biography']['value'] if orcid_bio['biography']
-          returning_value << response_builder.new('id' => identifier, 'label' => label, 'biography' => biography)
-        end
+        parser.call(document)
       end
 
     end

--- a/app/services/orcid/remote/profile_query_service/response_parser.rb
+++ b/app/services/orcid/remote/profile_query_service/response_parser.rb
@@ -1,0 +1,53 @@
+require_dependency 'orcid/remote/profile_query_service'
+module Orcid
+  module Remote
+    class ProfileQueryService
+      class ResponseParser
+
+        # A convenience method to expose entry into the ResponseParser function
+        def self.call(document, collaborators = {})
+          new(collaborators).call(document)
+        end
+
+        attr_reader :response_builder, :logger
+
+        def initialize(collaborators = {})
+          @response_builder = collaborators.fetch(:response_builder) do
+            SearchResponse
+          end
+          @logger = collaborators.fetch(:logger) do
+            Rails.logger
+          end
+        end
+
+        def call(document)
+          json = JSON.parse(document)
+          json.fetch('orcid-search-results').fetch('orcid-search-result')
+          .each_with_object([]) do |result, returning_value|
+            profile = result.fetch('orcid-profile')
+            begin
+              identifier = profile.fetch('orcid-identifier').fetch('path')
+              orcid_bio = profile.fetch('orcid-bio')
+              given_names = orcid_bio.fetch('personal-details').fetch('given-names').fetch('value')
+              family_name = orcid_bio.fetch('personal-details').fetch('family-name').fetch('value')
+              emails = []
+              contact_details = orcid_bio['contact-details']
+              if contact_details
+                emails = (contact_details['email'] || []).map {|email| email.fetch('value') }
+              end
+              label = "#{given_names} #{family_name}"
+              label << ' (' << emails.join(', ') << ')' if emails.any?
+              label << " [ORCID: #{identifier}]"
+              biography = ''
+              biography = orcid_bio['biography']['value'] if orcid_bio['biography']
+              returning_value << response_builder.new('id' => identifier, 'label' => label, 'biography' => biography)
+            rescue KeyError => e
+              logger.warn("Unexpected ORCID JSON Response, part of the response has been ignored.\tException Encountered:#{e.class}\t#{e}")
+            end
+            returning_value
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/public_api_query_spec.rb
+++ b/spec/features/public_api_query_spec.rb
@@ -28,6 +28,12 @@ describe 'public api query', requires_net_connect: true do
     Then { expect(result.size).to be > 0 }
   end
 
+  context 'with bogus text query' do
+    Given(:parameters) { { text: 'orcid@sufia.org' } }
+    When(:result) { runner.call(parameters) }
+    Then { expect(result.size).to eq 0 }
+  end
+
   context 'with a compound text query' do
     Given(:parameters) { { email: "nobody@gmail.com", text: '"Jeremy+Friesen"' } }
     When(:result) { runner.call(parameters) }

--- a/spec/fixtures/orcid-remote-profile_query_service-response_parser/multiple-responses-without-valid-response.json
+++ b/spec/fixtures/orcid-remote-profile_query_service-response_parser/multiple-responses-without-valid-response.json
@@ -1,0 +1,258 @@
+{
+  "message-version": "1.1",
+  "orcid-search-results": {
+    "orcid-search-result": [
+      {
+        "relevancy-score": {
+          "value": 0.016482107
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Reserved For Claim"
+              }
+            },
+            "keywords": null,
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      },
+      {
+        "relevancy-score": {
+          "value": 0.016482107
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Reserved For Claim"
+              }
+            },
+            "keywords": null,
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      },
+      {
+        "relevancy-score": {
+          "value": 0.016482107
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Reserved For Claim"
+              }
+            },
+            "keywords": null,
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      },
+      {
+        "relevancy-score": {
+          "value": 0.016482107
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Reserved For Claim"
+              }
+            },
+            "keywords": null,
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      },
+      {
+        "relevancy-score": {
+          "value": 0.016482107
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Reserved For Claim"
+              }
+            },
+            "keywords": null,
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      },
+      {
+        "relevancy-score": {
+          "value": 0.016482107
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Reserved For Claim"
+              }
+            },
+            "keywords": null,
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      },
+      {
+        "relevancy-score": {
+          "value": 0.016482107
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Reserved For Claim"
+              }
+            },
+            "keywords": null,
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      },
+      {
+        "relevancy-score": {
+          "value": 0.016482107
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Reserved For Claim"
+              }
+            },
+            "keywords": null,
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      },
+      {
+        "relevancy-score": {
+          "value": 0.016482107
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Reserved For Claim"
+              }
+            },
+            "keywords": null,
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      },
+      {
+        "relevancy-score": {
+          "value": 0.016482107
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Reserved For Claim"
+              }
+            },
+            "keywords": null,
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      }
+    ],
+    "num-found": 0
+  }
+}

--- a/spec/fixtures/orcid-remote-profile_query_service-response_parser/single-response-with-orcid-valid-profile.json
+++ b/spec/fixtures/orcid-remote-profile_query_service-response_parser/single-response-with-orcid-valid-profile.json
@@ -1,0 +1,71 @@
+{
+  "message-version": "1.1",
+  "orcid-search-results": {
+    "orcid-search-result": [
+      {
+        "relevancy-score": {
+          "value": 14.298138
+        },
+        "orcid-profile": {
+          "orcid": null,
+          "orcid-identifier": {
+            "value": null,
+            "uri": "http://orcid.org/MY-ORCID-PROFILE-ID",
+            "path": "MY-ORCID-PROFILE-ID",
+            "host": "orcid.org"
+          },
+          "orcid-bio": {
+            "personal-details": {
+              "given-names": {
+                "value": "Corwin"
+              },
+              "family-name": {
+                "value": "Amber"
+              }
+            },
+            "biography": {
+              "value": "MY-ORCID-BIOGRAPHY",
+              "visibility": null
+            },
+            "contact-details": {
+              "email": [
+                {
+                  "value": "MY-ORCID-EMAIL",
+                  "primary": true,
+                  "current": true,
+                  "verified": true,
+                  "visibility": null,
+                  "source": null
+                }
+              ],
+              "address": {
+                "country": {
+                  "value": "US",
+                  "visibility": null
+                }
+              }
+            },
+            "keywords": {
+              "keyword": [
+                {
+                  "value": "Lord of Amber"
+                }
+              ],
+              "visibility": null
+            },
+            "delegation": null,
+            "applications": null,
+            "scope": null
+          },
+          "orcid-activities": {
+            "affiliations": null
+          },
+          "type": null,
+          "group-type": null,
+          "client-type": null
+        }
+      }
+    ],
+    "num-found": 1
+  }
+}

--- a/spec/services/orcid/remote/profile_query_service/response_parser_spec.rb
+++ b/spec/services/orcid/remote/profile_query_service/response_parser_spec.rb
@@ -1,0 +1,43 @@
+require 'ostruct'
+require 'spec_helper'
+require 'orcid/remote/profile_query_service/response_parser'
+
+module Orcid
+  module Remote
+    class ProfileQueryService
+      describe ResponseParser do
+        context '.call' do
+          Given(:response_builder) { OpenStruct }
+          Given(:logger) { double(warn: true) }
+          Given(:document) do
+            File.read(fixture_file(File.join('orcid-remote-profile_query_service-response_parser',response_filename)))
+          end
+          Given(:subject) { described_class.new(response_builder: response_builder, logger: logger) }
+
+          context 'happy path' do
+            let(:response_filename) { 'single-response-with-orcid-valid-profile.json' }
+            When(:response) { subject.call(document) }
+            Then do
+              response.should eq(
+                [
+                  response_builder.new(
+                    id: "MY-ORCID-PROFILE-ID",
+                    label: "Corwin Amber (MY-ORCID-EMAIL) [ORCID: MY-ORCID-PROFILE-ID]",
+                    biography:"MY-ORCID-BIOGRAPHY"
+                  )
+                ]
+              )
+            end
+          end
+
+          context 'unhappy path' do
+            let(:response_filename) { 'multiple-responses-without-valid-response.json' }
+            When(:response) { subject.call(document) }
+            Then { response.should eq [] }
+            And { logger.should have_received(:warn).at_least(1).times }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/orcid/remote/profile_query_service_spec.rb
+++ b/spec/services/orcid/remote/profile_query_service_spec.rb
@@ -4,30 +4,24 @@ require 'ostruct'
 
 module Orcid::Remote
   describe ProfileQueryService do
-    Given(:email) { 'corwin@amber.gov' }
-    Given(:biography) { 'King of Amber' }
-    Given(:orcid_profile_id) { '0001-0002' }
+    Given(:parser) { double('Parser', call: parsed_response)}
     Given(:config) {
       {
         token: token,
         path: 'somehwere',
         headers: 'headers',
-        response_builder: OpenStruct,
+        parser: parser,
         query_parameter_builder: query_parameter_builder
       }
     }
-    Given(:query_parameter_builder) { double('Query Builder')}
-    Given(:response) { double("Response", body: response_body)} # See below
+    Given(:query_parameter_builder) { double('Query Builder') }
+    Given(:response) { double("Response", body: 'Response Body') }
     Given(:token) { double("Token") }
-    Given(:json_response) {
-      [
-        OpenStruct.new({ 'id' => orcid_profile_id, 'label' => "Corwin Amber (#{email}) [ORCID: #{orcid_profile_id}]", 'biography' => biography })
-      ]
-    }
     Given(:parameters) { double("Parameters") }
     Given(:normalized_parameters) { double("Normalized Parameters") }
     Given(:callback) { StubCallback.new }
     Given(:callback_config) { callback.configure(:found, :not_found) }
+    Given(:parsed_response) { 'HELLO WORLD!' }
 
     context '.call' do
       before(:each) do
@@ -35,84 +29,8 @@ module Orcid::Remote
         token.should_receive(:get).with(config[:path], headers: config[:headers], params: normalized_parameters).and_return(response)
       end
       When(:result) { described_class.call(parameters, config, &callback_config) }
-      Then { expect(result).to eq(json_response) }
-      And { expect(callback.invoked).to eq [:found, json_response] }
+      Then { expect(result).to eq(parsed_response) }
+      And { expect(callback.invoked).to eq [:found, parsed_response] }
     end
-
-    Given(:response_body) {
-      %(
-        {
-          "message-version": "1.1",
-          "orcid-search-results": {
-            "orcid-search-result": [
-              {
-                "relevancy-score": {
-                  "value": 14.298138
-                },
-                "orcid-profile": {
-                  "orcid": null,
-                  "orcid-identifier": {
-                    "value": null,
-                    "uri": "http://orcid.org/#{orcid_profile_id}",
-                    "path": "#{orcid_profile_id}",
-                    "host": "orcid.org"
-                  },
-                  "orcid-bio": {
-                    "personal-details": {
-                      "given-names": {
-                        "value": "Corwin"
-                      },
-                      "family-name": {
-                        "value": "Amber"
-                      }
-                    },
-                    "biography": {
-                      "value": "#{biography}",
-                      "visibility": null
-                    },
-                    "contact-details": {
-                      "email": [
-                        {
-                          "value": "#{email}",
-                          "primary": true,
-                          "current": true,
-                          "verified": true,
-                          "visibility": null,
-                          "source": null
-                        }
-                      ],
-                      "address": {
-                        "country": {
-                          "value": "US",
-                          "visibility": null
-                        }
-                      }
-                    },
-                    "keywords": {
-                      "keyword": [
-                        {
-                          "value": "Lord of Amber"
-                        }
-                      ],
-                      "visibility": null
-                    },
-                    "delegation": null,
-                    "applications": null,
-                    "scope": null
-                  },
-                  "orcid-activities": {
-                    "affiliations": null
-                  },
-                  "type": null,
-                  "group-type": null,
-                  "client-type": null
-                }
-              }
-            ],
-            "num-found": 1
-          }
-        }
-      )
-    }
   end
 end


### PR DESCRIPTION
I don't know if these are truly weird retults, but the resulting
document from the query says there are 0 results but includes 10 nodes
that look like they could be results.

The returned JSON document is captured in the newly committed file:
    multiple-responses-without-valid-response.json

Given the potential volatility of the response document from Orcid,
I've also opted to extract the parser for the response document.
In doing so, it is easier to unit test parsing the response.

Closes #2

Relates to: ORCID/ORCID-Source#1100
