### PR TITLE
Capturing predictable exceptions from Orcid

### DIFF
--- a/app/services/orcid/remote/profile_creation_service.rb
+++ b/app/services/orcid/remote/profile_creation_service.rb
@@ -1,8 +1,11 @@
 require 'orcid/remote/service'
+require 'oauth2/error'
+require 'nokogiri'
 module Orcid
   module Remote
     # Responsible for minting a new ORCID for the given payload.
     class ProfileCreationService < Orcid::Remote::Service
+      USER_WITH_THIS_EMAIL_ALREADY_EXISTS =  'User with this email already exists'.freeze
       def self.call(payload, config = {}, &callback_config)
         new(config, &callback_config).call(payload)
       end
@@ -20,6 +23,8 @@ module Orcid
       def call(payload)
         response = deliver(payload)
         parse(response)
+      rescue ::OAuth2::Error => e
+        parse_exception(e)
       end
 
       protected
@@ -37,6 +42,17 @@ module Orcid
         else
           callback(:failure)
           false
+        end
+      end
+
+      def parse_exception(exception)
+        doc = Nokogiri::XML.parse(exception.response.body)
+        error_text = doc.css('error-desc').text
+        if error_text == USER_WITH_THIS_EMAIL_ALREADY_EXISTS
+          callback(:orcid_email_already_exists, error_text)
+          false
+        else
+          fail exception
         end
       end
 

--- a/spec/services/orcid/remote/profile_creation_service_spec.rb
+++ b/spec/services/orcid/remote/profile_creation_service_spec.rb
@@ -11,30 +11,66 @@ module Orcid::Remote
       { 'Content-Type' => 'application/vdn.orcid+xml', 'Accept' => 'application/xml' }
     }
     Given(:callback) { StubCallback.new }
-    Given(:callback_config) { callback.configure }
+    Given(:callback_config) { callback.configure(:orcid_email_already_exists) }
 
     Given(:response) {
       double("Response", headers: { location: File.join("/", minted_orcid, "orcid-profile") })
     }
 
-    When(:returned_value) { described_class.call(payload, config, &callback_config) }
 
     context 'with orcid created' do
       Given(:response) {
         double("Response", headers: { location: File.join("/", minted_orcid, "orcid-profile") })
       }
+      When(:returned_value) { described_class.call(payload, config, &callback_config) }
       Then { returned_value.should eq(minted_orcid)}
       And { expect(callback.invoked).to eq [:success, minted_orcid] }
       And { token.should have_received(:post).with(config.fetch(:path), body: payload, headers: request_headers)}
     end
 
-    context 'with orcid created' do
+    context 'with orcid not created' do
       Given(:response) {
         double("Response", headers: { location: "" })
       }
+      When(:returned_value) { described_class.call(payload, config, &callback_config) }
       Then { returned_value.should eq(false)}
       And { expect(callback.invoked).to eq [:failure] }
       And { token.should have_received(:post).with(config.fetch(:path), body: payload, headers: request_headers)}
+    end
+
+    context 'with requested email already existing' do
+      before { token.should_receive(:post).and_raise(error) }
+      Given(:token) { double('Token') }
+      Given(:error_description) { described_class::USER_WITH_THIS_EMAIL_ALREADY_EXISTS }
+      Given(:response) do
+        double(
+          'Response',
+          :body => "<error-desc>#{error_description}</error-desc>",
+          :parsed => true,
+          :error= => true
+        )
+      end
+      Given(:error) { ::OAuth2::Error.new(response) }
+      When(:returned_value) { described_class.call(payload, config, &callback_config) }
+      Then { returned_value.should eq(false) }
+      And { expect(callback.invoked).to eq [:orcid_email_already_exists, error_description] }
+    end
+
+    context 'with another OAuth2 failure' do
+      before { token.should_receive(:post).and_raise(error) }
+      Given(:token) { double('Token') }
+      Given(:error_description) { 'Something Else' }
+      Given(:response) do
+        double(
+          'Response',
+          :body => "<error-desc>#{error_description}</error-desc>",
+          :parsed => true,
+          :error= => true
+        )
+      end
+      Given(:error) { ::OAuth2::Error.new(response) }
+      When(:returned_value) { described_class.call(payload, config, &callback_config) }
+      Then { expect(returned_value).to have_failed(OAuth2::Error) }
     end
   end
 end


### PR DESCRIPTION
When requesting the creation of an orcid profile, the remote service
could say the request is invalid.

More information at:
http://support.orcid.org/knowledgebase/articles/252102-api-error-codes

Closes #3
