### PR TITLE
Creating Orcid::ProfileStatus

### DIFF
--- a/app/models/orcid/profile_status.rb
+++ b/app/models/orcid/profile_status.rb
@@ -1,0 +1,67 @@
+module Orcid
+  # ProfileStatus.status
+  # **:authenticated_connection** - User has authenticated against the Orcid
+  #   remote system
+  # **:pending_connection** - User has indicated there is a connection, but has
+  #   not authenticated against the Orcid remote system
+  # **:profile_request_pending** - User has requested a profile be created on
+  #   their behalf
+  # **:unknown** - None of the above
+  class ProfileStatus
+    def self.for(user, collaborators = {}, &block)
+      new(user, collaborators, &block).status
+    end
+
+    attr_reader :user, :profile_finder, :request_finder, :callback_handler
+
+    def initialize(user, collaborators = {})
+      @user = user
+      @profile_finder = collaborators.fetch(:profile_finder) { default_profile_finder }
+      @request_finder = collaborators.fetch(:request_finder) { default_request_finder }
+      @callback_handler = collaborators.fetch(:callback_handler) { default_callback_handler }
+      yield(callback_handler) if block_given?
+    end
+
+    def status
+      return callback(:unknown) if user.nil?
+      profile = profile_finder.call(user)
+      if profile
+        if profile.verified_authentication?
+          return callback(:authenticated_connection, profile)
+        else
+          return callback(:pending_connection, profile)
+        end
+      else
+        request = request_finder.call(user)
+        if request
+          return callback(:profile_request_pending, request)
+        else
+          return callback(:unknown)
+        end
+      end
+      return callback(:unknown)
+    end
+
+    private
+
+    def callback(name, *args)
+      callback_handler.call(name, *args)
+      name
+    end
+
+    def default_callback_handler
+      require 'orcid/named_callbacks'
+      NamedCallbacks.new
+    end
+
+    def default_profile_finder
+      require 'orcid'
+      Orcid.method(:profile_for)
+    end
+
+    def default_request_finder
+      require 'orcid/profile_request'
+      ProfileRequest.method(:find_by_user)
+    end
+  end
+end

--- a/spec/models/orcid/profile_status_spec.rb
+++ b/spec/models/orcid/profile_status_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'orcid/profile_status'
+
+module Orcid
+  describe ProfileStatus do
+    Given(:user) { nil }
+    Given(:profile_finder) { double('ProfileFinder') }
+    Given(:request_finder) { double('RequestFinder') }
+    Given(:callback) { StubCallback.new }
+    Given(:callback_config) do
+      callback.configure(
+        :unknown,
+        :authenticated_connection,
+        :pending_connection,
+        :profile_request_pending
+      )
+    end
+    Given(:subject) do
+      described_class.new(user, profile_finder: profile_finder, request_finder: request_finder, &callback_config)
+    end
+
+    context '.for' do
+      Given(:user) { nil }
+      When(:response) { described_class.for(user, &callback_config) }
+      Then { expect(response).to eq :unknown }
+      And { expect(callback.invoked).to eq [:unknown] }
+    end
+
+    context '#status' do
+      context 'user is nil' do
+        Given(:user) { nil }
+        When(:status) { subject.status }
+        Then { expect(status).to eq :unknown }
+      end
+
+      context 'user is not nil' do
+        Given(:user) { double('User') }
+        Given(:profile_finder) { double('ProfileFinder', call: nil) }
+        Given(:request_finder) { double('RequestFinder', call: nil) }
+        context 'and has a profile' do
+          Given(:profile_finder) { double('ProfileFinder', call: profile) }
+          context 'that they have remotely authenticated' do
+            Given(:profile) { double('Profile', verified_authentication?: true) }
+            When(:status) { subject.status }
+            Then { expect(status).to eq :authenticated_connection }
+            And { expect(callback.invoked).to eq [:authenticated_connection, profile] }
+          end
+          context 'that they have not remotely authenticated' do
+            Given(:profile) { double('Profile', verified_authentication?: false) }
+            When(:status) { subject.status }
+            Then { expect(status).to eq :pending_connection }
+            And { expect(callback.invoked).to eq [:pending_connection, profile] }
+          end
+        end
+
+        context 'and does not have a profile' do
+          context 'but has submitted a request' do
+            Given(:request) { double('ProfileRequest') }
+            Given(:request_finder) { double('RequestFinder', call: request) }
+            When(:status) { subject.status }
+            Then { expect(status).to eq :profile_request_pending }
+            And { expect(callback.invoked).to eq [:profile_request_pending, request] }
+          end
+          context 'user does not have a request' do
+            When(:status) { subject.status }
+            Then { expect(status).to eq :unknown }
+            And { expect(callback.invoked).to eq [:unknown] }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an attempt to consolidate that knowledge.

There are several places in which we want to have access to a user's
Orcid Profile status, and methods related to those states.

The Orcid Profile Status makes use of callbacks because we do not
have a uniform object that represents each state for a user and their
orcid profile.

@TODO - review the controllers that have encapsulated this state and
have it lean on the Orcid::ProfileStatus handler.
