### PR TITLE
Conditional rendering for orcid profile connecter

### DIFF
--- a/app/views/orcid/profile_connections/_authenticated_connection.html.erb
+++ b/app/views/orcid/profile_connections/_authenticated_connection.html.erb
@@ -1,0 +1,5 @@
+<div class="authenticated-connection">
+  <p>
+    Your ORCID (<a class="orcid-profile-id" href="<%= Orcid.url_for_orcid_id(authenticated_connection.orcid_profile_id)%>" ><%= authenticated_connection.orcid_profile_id %></a>) has been authenticated for this application.
+  </p>
+</div>

--- a/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
+++ b/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
@@ -1,0 +1,20 @@
+<% profile_connection = Orcid::ProfileConnection.new %>
+<% default_search_text = '' unless defined?(default_search_text) %>
+<div class="options-to-connect-orcid-profile">
+  <p>
+    <%= link_to t('orcid/profile_connection.look_up_your_existing_orcid', scope: 'helpers.label'), orcid.new_profile_connection_path(profile_connection:{text: default_search_text}) %>
+  </p>
+  <p>
+    <%= link_to t('orcid/profile_connection.create_an_orcid', scope: 'helpers.label'), orcid.new_profile_request_path %>
+  </p>
+  <p>
+  <%= form_for(profile_connection, as: :profile_connection, url: orcid.profile_connections_path, method: :post) do |f| %>
+    <%# Note the `scope: 'helpers.label'` option is the default for the label, but I want to call those specifically out %>
+    <%= f.label :orcid_profile_id, t('orcid/profile_connection.orcid_profile_id', scope: 'helpers.label') %>
+    <%= f.text_field :orcid_profile_id, class:"orcid-input" %>
+    <button type="submit" class="search-submit btn btn-primary" id="keyword-search-submit" tabindex="2">
+      <span class="orcid-connect"><%= t('orcid/profile_connection.connect_button_text', scope: 'helpers.label') %></span>
+    </button>
+  <% end %>
+  </p>
+</div>

--- a/app/views/orcid/profile_connections/_orcid_connector.html.erb
+++ b/app/views/orcid/profile_connections/_orcid_connector.html.erb
@@ -1,22 +1,20 @@
-<% profile_connection = Orcid::ProfileConnection.new %>
-<% default_search_text = '' unless defined?(default_search_text) %>
+<% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for) %>
 <div class='orcid-connector'>
   <h3><i class="icon-user"></i> <%= link_to t('orcid.verbose_name'), 'http://orcid.org/' %></h3>
-  <p>
-    <%= link_to t('orcid/profile_connection.look_up_your_existing_orcid', scope: 'helpers.label'), orcid.new_profile_connection_path(profile_connection:{text: default_search_text}) %>
-  </p>
-  <p>
-    <%= link_to t('orcid/profile_connection.create_an_orcid', scope: 'helpers.label'), orcid.new_profile_request_path %>
-  </p>
-  <p>
-  <%= form_for(profile_connection, as: :profile_connection, url: orcid.profile_connections_path, method: :post) do |f| %>
-    <%# Note the `scope: 'helpers.label'` option is the default for the label, but I want to call those specifically out %>
-    <%= f.label :orcid_profile_id, value: t('orcid/profile_connection.connect_button_text', scope: 'helpers.label') %>
-    <%= f.text_field :orcid_profile_id, class:"orcid-input" %>
-    <button type="submit" class="search-submit btn btn-primary" id="keyword-search-submit" tabindex="2">
-      <span class="orcid-connect"><%= t('orcid/profile_connection.connect_button_text', scope: 'helpers.label') %></span>
-    </button>
+  <% status_processor.call(current_user) do |on|%>
+    <% on.profile_request_pending do |pending_request| %>
+      <%= render partial: 'profile_request_pending', object: pending_request %>
+    <% end %>
+    <% on.authenticated_connection do |profile| %>
+      <%= render partial: 'authenticated_connection', object: profile %>
+    <% end %>
+    <% on.pending_connection do |profile| %>
+      <%= render partial: 'pending_connection', object: profile %>
+    <% end %>
+    <% on.unknown do %>
+      <% defined?(default_search_text) || default_search_text = '' %>
+      <%= render partial: 'options_to_connect_orcid_profile', locals: { default_search_text: default_search_text } %>
+    <% end %>
   <% end %>
-  </p>
 </div>
 

--- a/app/views/orcid/profile_connections/_pending_connection.html.erb
+++ b/app/views/orcid/profile_connections/_pending_connection.html.erb
@@ -1,0 +1,11 @@
+<div class="pending-connection">
+  <p>
+    You have an ORCID (<a class="orcid-profile-id" href="<%= Orcid.url_for_orcid_id(pending_connection.orcid_profile_id)%>" ><%= pending_connection.orcid_profile_id %></a>).
+  </p>
+  <p>However, your ORCID has not been verified by this system. There are a few possibilities:
+    <ul>
+      <li>You may not have claimed your ORCID. <a class="find-out-more" href="http://support.orcid.org/knowledgebase/articles/164480-creating-claiming-new-records">Find out more about claiming your ORCID.</a></li>
+      <li>You have claimed your ORCID, but have not used it to <%= link_to('sign into this application', user_omniauth_authorize_path(provider: 'orcid'), class: 'signin-via-orcid') %>.</li>
+    </ul>
+  </p>
+</div>

--- a/app/views/orcid/profile_connections/_profile_request_pending.html.erb
+++ b/app/views/orcid/profile_connections/_profile_request_pending.html.erb
@@ -1,0 +1,5 @@
+<div class="profile-request-pending">
+  <p>We are processing your ORCID Profile Request. It was submitted
+    <time datetime="<%= profile_request_pending.created_at.in_time_zone %>"><%= time_ago_in_words(profile_request_pending.created_at) %></time> ago.
+  </p>
+</div>

--- a/spec/views/orcid/profile_connections/_authenticated_connection.html.erb_spec.rb
+++ b/spec/views/orcid/profile_connections/_authenticated_connection.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'orcid/profile_connections/_authenticated_connection.html.erb' do
+  Given(:profile) { double('Profile', orcid_profile_id: orcid_profile_id) }
+  Given(:orcid_profile_id) { '123-456' }
+
+  When(:rendered) do
+    render(
+      partial: 'orcid/profile_connections/authenticated_connection',
+      object: profile
+    )
+  end
+
+  Then do
+    expect(rendered).to have_tag('.authenticated-connection') do
+      with_tag('a.orcid-profile-id', text: orcid_profile_id)
+    end
+  end
+
+end

--- a/spec/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb_spec.rb
+++ b/spec/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'orcid/profile_connections/_options_to_connect_orcid_profile.html.erb' do
+  let(:default_search_text) { '' }
+  it 'renders a form' do
+    render
+    expect(rendered).to(
+      have_tag('.options-to-connect-orcid-profile') do
+        with_tag(
+          'a',
+          with: { href: orcid.new_profile_connection_path(profile_connection: { text: default_search_text }) },
+          text: t('orcid/profile_connection.look_up_your_existing_orcid', scope: 'helpers.label')
+        )
+        with_tag(
+          'a',
+          with: { href: orcid.new_profile_request_path },
+          text: t('orcid/profile_connection.create_an_orcid', scope: 'helpers.label')
+        )
+        with_tag('form', with: { method: 'post', action: orcid.profile_connections_path }) do
+          with_tag('label', text: t('orcid/profile_connection.orcid_profile_id', scope: 'helpers.label'))
+          with_tag('input', with: { type: 'text', name: 'profile_connection[orcid_profile_id]' })
+        end
+      end
+    )
+  end
+end

--- a/spec/views/orcid/profile_connections/_orcid_connector.html.erb_spec.rb
+++ b/spec/views/orcid/profile_connections/_orcid_connector.html.erb_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe 'orcid/profile_connections/_orcid_connector.html.erb' do
+  let(:default_search_text) { 'hello' }
+  let(:current_user) { double('User') }
+  let(:status_processor) { double('Processor') }
+  let(:handler) do
+    double(
+      'Handler',
+      profile_request_pending: true,
+      unknown: true,
+      authenticated_connection: true,
+      pending_connection: true
+    )
+  end
+  def render_with_params
+    render(
+      partial: 'orcid/profile_connections/orcid_connector',
+      locals: { default_search_text: default_search_text, status_processor: status_processor, current_user: current_user }
+    )
+  end
+
+  before do
+    status_processor.should_receive(:call).with(current_user).and_yield(handler)
+  end
+  context 'with :unknown status' do
+    it 'renders the options to connect orcid profile' do
+      expect(handler).to receive(:unknown).and_yield
+      render_with_params
+
+      expect(view).to render_template(partial: 'orcid/profile_connections/_options_to_connect_orcid_profile')
+      expect(rendered).to have_tag('.orcid-connector')
+    end
+  end
+  context 'with :profile_request_pending status' do
+    let(:pending_request) { double('Pending Request', created_at: Time.now) }
+    it 'renders the options to view the pending profile request' do
+      expect(handler).to receive(:profile_request_pending).and_yield(pending_request)
+      render_with_params
+
+      expect(view).to render_template(partial: 'orcid/profile_connections/_profile_request_pending')
+      expect(rendered).to have_tag('.orcid-connector')
+    end
+  end
+  context 'with :authenticated_connection status' do
+    let(:profile) { double('Profile', orcid_profile_id: '123-456') }
+    it 'renders the options to view the authenticated connection' do
+      expect(handler).to receive(:authenticated_connection).and_yield(profile)
+      render_with_params
+
+      expect(view).to render_template(partial: 'orcid/profile_connections/_authenticated_connection')
+      expect(rendered).to have_tag('.orcid-connector')
+    end
+  end
+  context 'with :pending_connection status' do
+    let(:profile) { double('Profile', orcid_profile_id: '123-456') }
+    it 'renders the options to view the authenticated connection' do
+      expect(handler).to receive(:pending_connection).and_yield(profile)
+      render_with_params
+
+      expect(view).to render_template(partial: 'orcid/profile_connections/_pending_connection')
+      expect(rendered).to have_tag('.orcid-connector')
+    end
+  end
+end

--- a/spec/views/orcid/profile_connections/_pending_connection.html.erb_spec.rb
+++ b/spec/views/orcid/profile_connections/_pending_connection.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'orcid/profile_connections/_pending_connection.html.erb' do
+  Given(:profile) { double('Profile', orcid_profile_id: orcid_profile_id) }
+  Given(:orcid_profile_id) { '123-456' }
+
+  When(:rendered) do
+    render(
+      partial: 'orcid/profile_connections/pending_connection',
+      object: profile
+    )
+  end
+
+  Then do
+    expect(rendered).to have_tag('.pending-connection') do
+      with_tag('a.orcid-profile-id', text: orcid_profile_id)
+      with_tag('a.find-out-more')
+      with_tag('a.signin-via-orcid')
+    end
+  end
+
+end

--- a/spec/views/orcid/profile_connections/_profile_request_pending.html.erb_spec.rb
+++ b/spec/views/orcid/profile_connections/_profile_request_pending.html.erb_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'orcid/profile_connections/_profile_request_pending.html.erb' do
+  Given(:profile_request) { double('ProfileRequest', created_at: created_at) }
+  Given(:created_at) { Date.today }
+
+  When(:rendered) do
+    render(
+      partial: 'orcid/profile_connections/profile_request_pending',
+      object: profile_request
+    )
+  end
+
+  Then do
+    expect(rendered).to have_tag('.profile-request-pending') do
+      with_tag(
+        'time',
+        with: { datetime: created_at.in_time_zone.to_s },
+        text: view.time_ago_in_words(created_at)
+      )
+    end
+  end
+
+end


### PR DESCRIPTION
The orcid profile connector should account for the identified states
of a user's orcid profile.

I have introduced a first pass at each of those options.

Closes to ndlib/sufia_orcid#4
