### PR TITLE
Fixing singular Rails resource behavior

### DIFF
--- a/app/controllers/orcid/profile_requests_controller.rb
+++ b/app/controllers/orcid/profile_requests_controller.rb
@@ -25,7 +25,17 @@ module Orcid
       return false if redirecting_because_user_has_existing_profile_request
       assign_attributes(new_profile_request)
       create_profile_request(new_profile_request)
-      respond_with(orcid, new_profile_request)
+      # As a named singular resource, url_for(profile_request) treates the
+      # input profile_request as the :format paramter. When you run
+      # `$ rake app:routes` in this gem, there is not a named route for:
+      # GET  /profile_request(.:format)         orcid/profile_requests#show
+      #
+      # Thus we need to pass the location.
+      if new_profile_request.valid?
+        respond_with(orcid, location: orcid.profile_request_path)
+      else
+        respond_with(orcid, new_profile_request)
+      end
     end
 
     protected

--- a/spec/routing/orcid/profile_request_routing_spec.rb
+++ b/spec/routing/orcid/profile_request_routing_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'Routes for Orcid::ProfileRequest' do
+  routes { Orcid::Engine.routes }
+  let(:persisted_profile) { Orcid::ProfileRequest.new(id: 2) }
+  it 'generates a conventional URL' do
+    expect(profile_request_path).
+      to(eq('/orcid/profile_request'))
+  end
+
+  it 'treats the input profile_request as the :format parameter' do
+    expect(profile_request_path(persisted_profile)).
+      to(eq("/orcid/profile_request.#{persisted_profile.to_param}"))
+  end
+end


### PR DESCRIPTION
Since we have a singular resource for ProfileRequest, the
`Controller#respond_with` was treating the profile_request parameter
as the :format option (i.e. format = 'xml').

The solution was to tease apart the automagic behavior of the
`#respond_with` method into its two response options for
transformative actions - either render the page with errors or
redirect due to success.

I believe this is related to https://github.com/rails/rails/issues/1769,
which is called out in http://guides.rubyonrails.org/routing.html#singular-resources

Below is a more detailed breakdown of what I am refering to:

The ProfileRequest is a singular resource.

``` ruby
Orcid::Engine.routes.draw do
  scope module: 'orcid' do
    resource :profile_request, only: [:show, :new, :create]
    resources :profile_connections, only: [:new, :create, :index]
  end
end
```

As a singluar resource the following routes are available.

``` console
$ rake app:routes
Routes for Orcid::Engine:
   profile_request  POST /profile_request(.:format)     orcid/profile_requests#create
new_profile_request GET  /profile_request/new(.:format) orcid/profile_requests#new
                    GET  /profile_request(.:format)     orcid/profile_requests#show
```

If we had a plural resource for ProfileRequest

``` ruby
Orcid::Engine.routes.draw do
  scope module: 'orcid' do
    resources :profile_request, only: [:show, :new, :create]
    resources :profile_connections, only: [:new, :create, :index]
  end
end
```

Then the routes would be:

``` console
$ rake app:routes
profile_request_index POST /profile_request(.:format)     orcid/profile_request#create
  new_profile_request GET  /profile_request/new(.:format) orcid/profile_request#new
      profile_request GET  /profile_request/:id(.:format) orcid/profile_request#show
```
