### PR TITLE
Adding mailmap for author disambiguation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Dan Brubaker Horst <dan@brubakerhorst.com> <dan.brubaker.horst@gmail.com>
+Glen Horton <hortongn@ucmail.uc.edu> <glen.horton@gmail.com>
+Carolyn Cole <cam156@psu.edu> cam156


### PR DESCRIPTION
Some of the authors on the project have commits under two different
identities. Making sure those authors are counted as one.

[skip ci]
