### PR TITLE
Teasing apart when coveralls runs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start 'rails'
   SimpleCov.command_name "spec"
+end
+
+if ENV['TRAVIS']
   require 'coveralls'
   Coveralls.wear!('rails')
 end


### PR DESCRIPTION
I noticed that if Simplecov was running and Coveralls was also
configured within the same block, that the Simplecov ./coverage
directory was not being updated.

This is an effort to tease that apart.
