### PR TITLE
Introducing ProfileRequestCoordinator

### DIFF
--- a/app/controllers/orcid/profile_requests_controller.rb
+++ b/app/controllers/orcid/profile_requests_controller.rb
@@ -71,7 +71,7 @@ module Orcid
     end
 
     def create_profile_request(profile_request)
-      profile_request.save && Orcid.enqueue(profile_request)
+      profile_request.save && Orcid::ProfileRequestCoordinator.call(profile_request)
     end
 
     def profile_request_params

--- a/app/models/orcid/profile_request.rb
+++ b/app/models/orcid/profile_request.rb
@@ -18,90 +18,16 @@ module Orcid
 
     belongs_to :user
 
-    def run(options = {})
-      # Why dependency injection? Because this is going to be a plugin, and
-      # things can't possibly be simple. I also found it easier to test the
-      # #run method with these injected dependencies
-      validator = options.fetch(:validator) { method(:validate_before_run) }
-      return false unless validator.call(self)
-
-      payload_xml_builder = options.fetch(:payload_xml_builder) do
-        method(:xml_payload)
-      end
-      profile_creation_service = options.fetch(:profile_creation_service) do
-        default_profile_creation_service
-      end
-      profile_creation_service.call(payload_xml_builder.call(attributes))
-    end
-
-    def default_profile_creation_service
-      @default_profile_creation_service ||= begin
-        Orcid::Remote::ProfileCreationService.new do |on|
-          on.success do |orcid_profile_id|
-            handle_profile_creation_response(orcid_profile_id)
-          end
-        end
-      end
-    end
-
-    def validate_before_run(context = self)
-      validate_profile_id_is_unassigned(context) &&
-        validate_user_does_not_have_profile(context)
-    end
-
-    def validate_user_does_not_have_profile(context)
-      user_orcid_profile = Orcid.profile_for(context.user)
-      return true unless user_orcid_profile
-      message = "#{context.class} ID=#{context.to_param}'s associated user" \
-       " #{context.user.to_param} already has an assigned :orcid_profile_id" \
-       " #{user_orcid_profile.to_param}"
-      context.errors.add(:base, message)
-      false
-    end
-    private :validate_user_does_not_have_profile
-
-    def validate_profile_id_is_unassigned(context)
-      return true unless context.orcid_profile_id?
-      message = "#{context.class} ID=#{context.to_param} already has an" \
-        " assigned :orcid_profile_id #{context.orcid_profile_id.inspect}"
-      context.errors.add(:base, message)
-      false
-    end
-    private :validate_profile_id_is_unassigned
-
-    # NOTE: This one lies ->
-    #   http://support.orcid.org/knowledgebase/articles/177522-create-an-id-technical-developer
-    # NOTE: This one was true at 2014-02-06:14:55 ->
-    #   http://support.orcid.org/knowledgebase/articles/162412-tutorial-create-a-new-record-using-curl
-    def xml_payload(input = attributes)
-      attrs = input.with_indifferent_access
-      returning_value = <<-XML_TEMPLATE
-      <?xml version="1.0" encoding="UTF-8"?>
-      <orcid-message
-      xmlns:xsi="http://www.orcid.org/ns/orcid https://raw.github.com/ORCID/ORCID-Source/master/orcid-model/src/main/resources/orcid-message-1.1.xsd"
-      xmlns="http://www.orcid.org/ns/orcid">
-      <message-version>1.1</message-version>
-      <orcid-profile>
-      <orcid-bio>
-      <personal-details>
-      <given-names>#{attrs.fetch('given_names')}</given-names>
-      <family-name>#{attrs.fetch('family_name')}</family-name>
-      </personal-details>
-      <contact-details>
-      <email primary="true">#{attrs.fetch('primary_email')}</email>
-      </contact-details>
-      </orcid-bio>
-      </orcid-profile>
-      </orcid-message>
-      XML_TEMPLATE
-      returning_value.strip
-    end
-
-    def handle_profile_creation_response(orcid_profile_id)
+    def successful_profile_creation(orcid_profile_id)
       self.class.transaction do
         update_column(:orcid_profile_id, orcid_profile_id)
         Orcid.connect_user_and_orcid_profile(user, orcid_profile_id)
       end
     end
+
+    def validation_error_on_profile_creation(error_message)
+      update_column(:response_text, error_message)
+    end
+
   end
 end

--- a/app/services/orcid/profile_request_coordinator.rb
+++ b/app/services/orcid/profile_request_coordinator.rb
@@ -1,0 +1,112 @@
+require 'orcid/exceptions'
+
+module Orcid
+  # Responsible for converting an Orcid::ProfileRequest into an Orcid::Profile.
+  class ProfileRequestCoordinator
+
+    def self.call(profile_request, collaborators = {})
+      new(profile_request, collaborators).call
+    end
+
+    def initialize(profile_request, collaborators = {})
+      self.profile_request = profile_request
+      @remote_service = collaborators.fetch(:remote_service) { default_remote_service }
+      @profile_state_finder = collaborators.fetch(:profile_state_finder) { default_profile_state_finder }
+      @logger = collaborators.fetch(:logger) { default_logger }
+    end
+
+    attr_reader :profile_request, :remote_service, :profile_state_finder, :logger
+    private :remote_service, :profile_state_finder, :logger
+
+    def call
+      profile_state_finder.call(user) do |on|
+        on.unknown { handle_unknown_profile_state }
+        on.profile_request_pending { |request| handle_profile_request }
+        on.pending_connection { |profile| handle_pending_connection_for(profile) }
+        on.authenticated_connection { |profile| handle_authenticated_connection_for(profile) }
+      end
+      true
+    end
+
+    private
+
+    def handle_profile_request
+      payload = xml_payload(profile_request)
+      remote_service.call(payload) do |on|
+        on.success { |orcid_profile_id| profile_request.successful_profile_creation(orcid_profile_id) }
+        on.failure { }
+        on.orcid_validation_error { |error_message| profile_request.validation_error_on_profile_creation(error_message) }
+      end
+    end
+
+    protected
+
+    def profile_request=(request)
+      if !request.respond_to?(:user) || !request.user.present?
+        fail MissingUserForProfileRequest, request
+      end
+      if !request.respond_to?(:validation_error_on_profile_creation)
+        raise ProfileRequestMethodExpectedError.new(request, :validation_error_on_profile_creation)
+      end
+      if !request.respond_to?(:successful_profile_creation)
+        raise ProfileRequestMethodExpectedError.new(request, :successful_profile_creation)
+      end
+      @profile_request = request
+    end
+
+    def user
+      profile_request.user
+    end
+
+    private
+
+    def default_logger
+      Rails.logger
+    end
+
+    def default_remote_service
+      require 'orcid/remote/profile_creation_service'
+      Orcid::Remote::ProfileCreationService
+    end
+
+    def default_profile_state_finder
+      require 'orcid/profile_status'
+      Orcid::ProfileStatus.method(:for)
+    end
+
+    def handle_unknown_profile_state
+      require 'orcid/exceptions'
+      fail Orcid::ProfileRequestStateError, user
+    end
+
+    def handle_pending_connection_for(profile)
+      message = "Attempted to request ORCID for #{profile_request.class} ID=#{profile_request.to_param}."
+      message << " There is a pending connection for #{user.class} ID=#{user.to_param}."
+      logger.notice(message)
+    end
+
+    def handle_authenticated_connection_for(profile)
+      message = "Attempted to request ORCID for #{profile_request.class} ID=#{profile_request.to_param}."
+      message << " There is an authenticated connection for  #{user.class} ID=#{user.to_param}."
+      logger.notice(message)
+    end
+
+    def xml_payload(request)
+      attrs = request.attributes.with_indifferent_access
+      returning_value = <<-XML_TEMPLATE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <orcid-message
+      xmlns:xsi="http://www.orcid.org/ns/orcid https://raw.github.com/ORCID/ORCID-Source/master/orcid-model/src/main/resources/orcid-message-1.1.xsd"
+      xmlns="http://www.orcid.org/ns/orcid">
+      <message-version>1.1</message-version>
+      <orcid-profile>\n<orcid-bio>\n<personal-details>
+      <given-names>#{attrs.fetch('given_names')}</given-names>
+      <family-name>#{attrs.fetch('family_name')}</family-name>
+      </personal-details>\n<contact-details>
+      <email primary="true">#{attrs.fetch('primary_email')}</email>
+      </contact-details>\n</orcid-bio>\n</orcid-profile>\n</orcid-message>
+      XML_TEMPLATE
+      returning_value.strip
+    end
+  end
+end

--- a/db/migrate/20140205185339_update_orcid_profile_requests.rb
+++ b/db/migrate/20140205185339_update_orcid_profile_requests.rb
@@ -1,0 +1,6 @@
+class UpdateOrcidProfileRequests < ActiveRecord::Migration
+  def change
+    add_column :orcid_profile_requests, :response_text, :text
+    add_column :orcid_profile_requests, :response_status, :string, index: true
+  end
+end

--- a/lib/orcid/exceptions.rb
+++ b/lib/orcid/exceptions.rb
@@ -1,6 +1,28 @@
 module Orcid
 
-  class ConfigurationError < RuntimeError
+  # Intended to be the base for all exceptions raised by the Orcid gem.
+  class BaseError < RuntimeError
+  end
+
+  class ProfileRequestStateError < BaseError
+    def initialize(user)
+      super("Unexpected Orcid::ProfileRequest state for #{user.class} ID=#{user.to_param}.")
+    end
+  end
+
+  class ProfileRequestMethodExpectedError < BaseError
+    def initialize(request, method_name)
+      super("Expected #{request.inspect} to respond to :#{method_name}.")
+    end
+  end
+
+  class MissingUserForProfileRequest < BaseError
+    def initialize(request)
+      super("#{request.class} ID=#{request.to_param} is not associated with a :user.")
+    end
+  end
+
+  class ConfigurationError < BaseError
     def initialize(key_name)
       super("Unable to find #{key_name.inspect} in configuration storage.")
     end
@@ -8,7 +30,7 @@ module Orcid
 
   # Because in trouble shooting what all goes into this remote call,
   # you may very well want all of this.
-  class RemoteServiceError < RuntimeError
+  class RemoteServiceError < BaseError
     def initialize(options)
       text = []
       text << "-- Client --"

--- a/spec/controllers/orcid/profile_requests_controller_spec.rb
+++ b/spec/controllers/orcid/profile_requests_controller_spec.rb
@@ -96,7 +96,7 @@ module Orcid
 
         it 'should render a profile request form' do
           Orcid::ProfileRequest.should_receive(:find_by_user).with(user).and_return(nil)
-          Orcid.should_receive(:enqueue).with(an_instance_of(Orcid::ProfileRequest))
+          Orcid::ProfileRequestCoordinator.should_receive(:call).with(an_instance_of(Orcid::ProfileRequest))
 
           expect do
             post :create, profile_request: profile_request_attributes, use_route: :orcid
@@ -106,7 +106,7 @@ module Orcid
 
         it 'should handle invalid data' do
           Orcid::ProfileRequest.should_receive(:find_by_user).with(user).and_return(nil)
-          Orcid.should_not_receive(:enqueue)
+          Orcid::ProfileRequestCoordinator.should_not_receive(:call)
 
           expect do
             post :create, profile_request: {}, use_route: :orcid

--- a/spec/features/non_ui_based_interactions_spec.rb
+++ b/spec/features/non_ui_based_interactions_spec.rb
@@ -21,6 +21,7 @@ describe 'non-UI based interactions' , requires_net_connect: true do
     let(:profile_request) {
       FactoryGirl.create(:orcid_profile_request, user: user, primary_email: email, primary_email_confirmation: email)
     }
+    let(:profile_request_coordinator) { Orcid::ProfileRequestCoordinator.new(profile_request)}
 
     before(:each) do
       # Making sure things are properly setup
@@ -28,7 +29,8 @@ describe 'non-UI based interactions' , requires_net_connect: true do
     end
 
     it 'creates a profile' do
-      profile_request.run
+      profile_request_coordinator.call
+      profile_request.reload
 
       orcid_profile_id = profile_request.orcid_profile_id
 

--- a/spec/lib/orcid/exceptions_spec.rb
+++ b/spec/lib/orcid/exceptions_spec.rb
@@ -1,0 +1,33 @@
+require 'fast_helper'
+require 'orcid/exceptions'
+
+module Orcid
+  describe BaseError do
+    it { should be_a_kind_of RuntimeError }
+  end
+
+  describe ProfileRequestStateError do
+    subject { described_class }
+    its(:superclass) { should be BaseError }
+  end
+
+  describe MissingUserForProfileRequest do
+    subject { described_class }
+    its(:superclass) { should be BaseError }
+  end
+
+  describe ConfigurationError do
+    subject { described_class }
+    its(:superclass) { should be BaseError }
+  end
+
+  describe RemoteServiceError do
+    subject { described_class }
+    its(:superclass) { should be BaseError }
+  end
+
+  describe ProfileRequestMethodExpectedError do
+    subject { described_class }
+    its(:superclass) { should be BaseError }
+  end
+end

--- a/spec/models/orcid/profile_request_spec.rb
+++ b/spec/models/orcid/profile_request_spec.rb
@@ -27,104 +27,22 @@ module Orcid
 
     end
 
-    context '#handle_profile_creation_response' do
-      it 'should update local' do
+    context '#successful_profile_creation' do
+      it 'should update profile request' do
         # Don't want to hit the database
         subject.should_receive(:update_column).with(:orcid_profile_id, orcid_profile_id)
         Orcid.should_receive(:connect_user_and_orcid_profile).with(user, orcid_profile_id)
 
-        subject.handle_profile_creation_response(orcid_profile_id)
+        subject.successful_profile_creation(orcid_profile_id)
       end
     end
 
-    context '#xml_payload' do
-      it 'should be a parsable XML document' do
-        expect {
-          ActiveSupport::XmlMini.parse(subject.xml_payload)
-        }.to_not raise_error
-      end
-    end
-
-    context '#validate_before_run' do
-      let(:orcid_profile) { double('Orcid Profile', to_param: orcid_profile_id) }
-
-      context 'when no orcid profile has been assigned' do
-        before { Orcid.should_receive(:profile_for).with(user).and_return(nil) }
-        it 'should return true' do
-          expect(subject.validate_before_run).to eq(true)
-        end
-      end
-
-      context 'orcid_profile_id is set' do
-        before { subject.orcid_profile_id = orcid_profile_id }
-
-        it 'should return false' do
-          expect(subject.validate_before_run).to eq(false)
-        end
-
-        it 'should set an error' do
-          expect {
-            subject.validate_before_run
-          }.to change { subject.errors.full_messages.count }.by(1)
-        end
-
-      end
-
-      context 'user has an orcid_profile' do
-        before { Orcid.should_receive(:profile_for).with(user).and_return(orcid_profile) }
-
-        it 'should return false' do
-          expect(subject.validate_before_run).to eq(false)
-        end
-
-        it 'should set an error' do
-          expect {
-            subject.validate_before_run
-          }.to change { subject.errors.full_messages.count }.by(1)
-        end
-
-      end
-    end
-
-    context '#run' do
-      let(:profile_creation_service) { double('Profile Creation Service') }
-      let(:payload_xml_builder) { double('Payload Xml Builder') }
-      let(:validator) { double('Submission Guardian') }
-      let(:xml_payload) { double('Xml Payload') }
-
-      context 'with the submission guardian permitting the request' do
-        before(:each) do
-          validator.should_receive(:call).with(subject).
-            and_return(true)
-          payload_xml_builder.should_receive(:call).with(subject.attributes).
-            and_return(xml_payload)
-          profile_creation_service.should_receive(:call).with(xml_payload).
-            and_return(orcid_profile_id)
-        end
-
-        it 'should run a request and handle the response' do
-          subject.run(
-            payload_xml_builder: payload_xml_builder,
-            profile_creation_service: profile_creation_service,
-            validator: validator
-          )
-        end
-      end
-
-      context 'with the submission guardian returning false' do
-        before(:each) do
-          validator.should_receive(:call).with(subject).
-            and_return(false)
-          payload_xml_builder.should_not_receive(:call)
-        end
-
-        it 'should raise an exception' do
-          subject.run(
-            payload_xml_builder: payload_xml_builder,
-            profile_creation_service: profile_creation_service,
-            validator: validator
-          )
-        end
+    context '#validation_error_on_profile_creation' do
+      it 'should update profile request' do
+        error_message = '123'
+        # Don't want to hit the database
+        subject.should_receive(:update_column).with(:response_text, error_message)
+        subject.validation_error_on_profile_creation(error_message)
       end
     end
   end

--- a/spec/services/orcid/profile_request_coordinator_spec.rb
+++ b/spec/services/orcid/profile_request_coordinator_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+require 'orcid/profile_request_coordinator'
+
+module Orcid
+  describe ProfileRequestCoordinator do
+    before(:each) do
+      profile_state_finder.stub(:call).and_yield(callback_responder)
+    end
+    Given(:logger) { double('Logger', notice: true) }
+    Given(:user) { 'user' }
+    Given(:profile_request) { double('ProfileRequest', user: user, successful_profile_creation: true, validation_error_on_profile_creation: true) }
+    Given(:remote_service) { double('Remote Service') }
+    Given(:callback_responder) do
+      double('Responder', unknown: true, authenticated_connection: true, profile_request_pending: true, pending_connection: true)
+    end
+    Given(:profile_state_finder) { double('ProfileStateFinder', call: true) }
+    Given(:coordinator) do
+      described_class.new(
+        profile_request,
+        remote_service: remote_service,
+        profile_state_finder: profile_state_finder,
+        logger: logger
+      )
+    end
+
+    context '.call' do
+      When(:response) do
+        described_class.call(
+          profile_request,
+          remote_service: remote_service,
+          profile_state_finder: profile_state_finder,
+          logger: logger
+        )
+      end
+      Then { expect(response).to eq(true) }
+    end
+
+    context 'on profile_request_pending state' do
+      Given(:remote_service_handler) { double('Handler', success: true, failure: true, orcid_validation_error: true) }
+      Given(:attributes) { { given_names: 'Given', family_name: 'Family', primary_email: 'email@email.email' } }
+      Given(:profile_request) do
+        double('ProfileRequest', user: user, attributes: attributes, successful_profile_creation: true, validation_error_on_profile_creation: true)
+      end
+      before do
+        callback_responder.stub(:profile_request_pending).and_yield(profile_request)
+        remote_service.should_receive(:call).and_yield(remote_service_handler)
+      end
+
+      context 'successful profile request' do
+        before do
+          remote_service_handler.should_receive(:success).and_yield(orcid_profile_id)
+        end
+        Given(:orcid_profile_id) { '0000-0001-0002-0003' }
+        When { coordinator.call }
+        Then { expect(profile_request).to have_received(:successful_profile_creation).with(orcid_profile_id) }
+      end
+      context 'encountering a orcid validation error' do
+        before do
+          remote_service_handler.should_receive(:orcid_validation_error).and_yield(error_message)
+        end
+        Given(:error_message) { 'Error Message' }
+        When { coordinator.call }
+        Then { expect(profile_request).to have_received(:validation_error_on_profile_creation).with(error_message) }
+      end
+    end
+
+    context 'requires a user for the profile_request' do
+      Given(:profile_request) { double('ProfileRequest') }
+      When(:instantiation) { described_class.new(profile_request) }
+      Then { expect(instantiation).to have_failed(MissingUserForProfileRequest) }
+    end
+
+    context 'requires a validation_error_on_profile_creation for the profile_request' do
+      Given(:profile_request) { double('ProfileRequest', user: 'user') }
+      When(:instantiation) { described_class.new(profile_request) }
+      Then { expect(instantiation).to have_failed(ProfileRequestMethodExpectedError) }
+    end
+
+    context 'requires a validation_error_on_profile_creation for the profile_request' do
+      Given(:profile_request) { double('ProfileRequest', user: 'user', validation_error_on_profile_creation: true) }
+      When(:instantiation) { described_class.new(profile_request) }
+      Then { expect(instantiation).to have_failed(ProfileRequestMethodExpectedError) }
+    end
+
+    context 'on unknown state' do
+      before do
+        callback_responder.stub(:unknown).and_yield
+      end
+      When(:response) { coordinator.call }
+      Then { expect(response).to have_failed(ProfileRequestStateError) }
+    end
+
+    context 'on pending_connection state' do
+      before do
+        callback_responder.stub(:pending_connection).and_yield(profile)
+      end
+      Given(:profile) { double('Profile') }
+      When { coordinator.call }
+      Then { expect(logger).to have_received(:notice) }
+    end
+
+    context 'on handle_authenticated_connection_for state' do
+      before do
+        callback_responder.stub(:authenticated_connection).and_yield(profile)
+      end
+      Given(:profile) { double('Profile') }
+      When { coordinator.call }
+      Then { expect(logger).to have_received(:notice) }
+    end
+  end
+end


### PR DESCRIPTION
Responsible for converting an Orcid::ProfileRequest into an
Orcid::Profile.

The Orcid::ProfileRequest object was doing too many things (i.e.
persisting the profile request then handling the remote interaction
with orcid.org).

I'm trying to tease apart the offline coordinator for the profile
request. Basically separating the persistence of the initial request
to processing that persisted request.

Also, this pull request includes adjusting Orcid exceptions
inheritance.

I want to provide a base error from which Orcid errors are built from.
That way, someone could feasibly rescue an Orcid::BaseError exception
and handle in a uniform manner.
