### PR TITLE
Improving user experienc for profile creation

### DIFF
--- a/app/controllers/orcid/application_controller.rb
+++ b/app/controllers/orcid/application_controller.rb
@@ -1,6 +1,13 @@
 module Orcid
   # The foundation for Orcid controllers. A few helpful accessors.
   class ApplicationController < Orcid.parent_controller.constantize
+    # Providing a mechanism for overrding the default path in an implementing
+    # application
+    def path_for(named_path, *args)
+      return send(named_path, *args).to_s if respond_to?(named_path)
+      yield(*args)
+    end
+
     private
 
     def redirecting_because_user_has_connected_orcid_profile
@@ -9,7 +16,7 @@ module Orcid
           'orcid.requests.messages.previously_connected_profile',
           orcid_profile_id: orcid_profile.orcid_profile_id
         )
-        redirect_to main_app.root_path
+        redirect_to path_for(:orcid_settings_path) { main_app.root_path }
         return true
       else
         return false

--- a/app/controllers/orcid/profile_connections_controller.rb
+++ b/app/controllers/orcid/profile_connections_controller.rb
@@ -72,7 +72,8 @@ module Orcid
         'orcid.connections.messages.verified_profile_connection_exists',
         orcid_profile_id: orcid_profile.orcid_profile_id
       )
-      redirect_to('/', flash: { notice: notice })
+      location = path_for(:orcid_settings_path) { main_app.root_path }
+      redirect_to(location, flash: { notice: notice })
     end
   end
 end

--- a/app/controllers/orcid/profile_requests_controller.rb
+++ b/app/controllers/orcid/profile_requests_controller.rb
@@ -36,7 +36,15 @@ module Orcid
       #
       # Thus we need to pass the location.
       if new_profile_request.valid?
-        respond_with(orcid, location: orcid.profile_request_path)
+        flash[:notice] = I18n.t(
+          'orcid.requests.messages.profile_request_created'
+        )
+
+        location = path_for(:after_successful_orcid_profile_request_path) do
+          orcid.profile_request_path
+        end
+
+        respond_with(orcid, location: location)
       else
         respond_with(orcid, new_profile_request)
       end

--- a/config/locales/orcid.en.yml
+++ b/config/locales/orcid.en.yml
@@ -26,6 +26,7 @@ en:
         existing_request_not_found: "Unable to find an existing Orcid Profile request. Go ahead and create one."
         existing_request: "You have already submitted an Orcid Profile request."
         previously_connected_profile: "You have already connected to an Orcid Profile (%{orcid_profile_id})."
+        profile_request_created: "Your Orcid profile request has been submitted. Check your email for more information from Orcid."
     connections:
       messages:
         profile_connection_not_found: "Unable to find an existing Orcid Profile connection."

--- a/spec/controllers/orcid/application_controller_spec.rb
+++ b/spec/controllers/orcid/application_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Orcid::ApplicationController, type: :controller do
+  context '#path_for' do
+    it 'yields when the provided symbol is not a method' do
+      path_for = controller.path_for(:__obviously_missing_method__, '123') { |arg| "/abc/#{arg}" }
+      expect(path_for).to eq('/abc/123')
+    end
+
+    it 'calls the named method' do
+      path_for = controller.path_for(:to_s) { "/abc/#{arg}" }
+      expect(path_for).to eq(controller.to_s)
+    end
+  end
+end

--- a/spec/controllers/orcid/profile_requests_controller_spec.rb
+++ b/spec/controllers/orcid/profile_requests_controller_spec.rb
@@ -101,6 +101,7 @@ module Orcid
           expect do
             post :create, profile_request: profile_request_attributes, use_route: :orcid
           end.to change { Orcid::ProfileRequest.count }.by(1)
+          expect(flash[:notice]).to eq(I18n.t('orcid.requests.messages.profile_request_created'))
           expect(response).to redirect_to(orcid.profile_request_path)
         end
 


### PR DESCRIPTION
Prior to this commit, there was no confirmation that the profile
request was. The process was also injecting confusing redirects.

Many of the routing decisions in this micro-application are not
adequate for implementing applications.

By introducing the #path_for method, I'm hoping to provide a means
for adopters to override redirect behavior.

Closes #41
