### PR TITLE
Adding Orcid.disconnect_user_and_orcid_profile

### DIFF
--- a/lib/orcid.rb
+++ b/lib/orcid.rb
@@ -62,6 +62,10 @@ module Orcid
     return false
   end
 
+  def disconnect_user_and_orcid_profile(user)
+    authentication_model.where(provider: 'orcid', user: user).destroy_all
+  end
+
   def profile_for(user)
     auth = authentication_model.where(provider: 'orcid', user: user).first
     auth && Orcid::Profile.new(auth.uid)

--- a/spec/lib/orcid_spec.rb
+++ b/spec/lib/orcid_spec.rb
@@ -60,6 +60,14 @@ describe Orcid do
     end
   end
 
+  context '.disconnect_user_and_orcid_profile' do
+    it 'changes the authentication count' do
+      Orcid.connect_user_and_orcid_profile(user, orcid_profile_id)
+      expect { Orcid.disconnect_user_and_orcid_profile(user) }.
+        to change(Orcid.authentication_model, :count).by(-1)
+    end
+  end
+
   context '.access_token_for' do
     let(:client) { double("Client")}
     let(:token) { double('Token') }


### PR DESCRIPTION
Exposing a means for disconnecting user and profile; This is a common
task for QA and development, so it should be exposed. It is also
something that will be required (on occassion) in production
environments because users will encounter problems.
